### PR TITLE
add RequestExecutionLevel

### DIFF
--- a/template_source/installer/win64.nsi
+++ b/template_source/installer/win64.nsi
@@ -20,6 +20,9 @@ OutFile "..\build\${APPNAME}-Setup-x64.exe"
 # Destintation install directory
 InstallDir "$PROGRAMFILES\${APPNAME}"
 
+# Install as administrator
+RequestExecutionLevel admin
+
 # default section start
 Section
 


### PR DESCRIPTION
Windows Vista and later need administrator rights to write files to `$PROGRAMFILES` or or change the registry in `HKLM`. I assume the installer already claimed admin rights on launch, but it's recommended to explicitly do so.
